### PR TITLE
Handle subscription cancel by exiting process

### DIFF
--- a/src/vent_subscriber.erl
+++ b/src/vent_subscriber.erl
@@ -148,6 +148,9 @@ handle_message({#'basic.deliver'{consumer_tag = Tag}, #amqp_msg{}} = Message,
     folsom_metrics:notify({?METRIC_IN, {inc, 1}}),
     State1 = call_handler(#{msg => Message, processing_start => T0}, State),
     {ok, State1};
+handle_message(#'basic.cancel'{}, State) ->
+    exit(canceled),
+    {ok, State};
 handle_message(_, _State) ->
     false.
 


### PR DESCRIPTION
In a clustered environment, if a queue dies or is moved, RabbitMQ
will cancel the subscription. A cancellation message looks like
{'basic.cancel', Tag, true}. The vent_subscriber process is responsible
for subscribing to a given queue, and it performs the subscription on
its initialisation. Therefore, if we wish to re-subscribe, it is simple
enough to make the process exit, and have its supervisor restart it,
which will cause a new subscription.