### PR TITLE
Add ability to set exchange options in publish

### DIFF
--- a/src/vent_publisher.erl
+++ b/src/vent_publisher.erl
@@ -2,7 +2,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/2, publish/3]).
+-export([start_link/2, publish/3, publish/4]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -21,9 +21,10 @@
 -type opts() :: #{id => term(),
                   chunk_size => pos_integer()}.
 
--type exchange() :: binary().
--type topic() :: binary().
--type sample() :: #{}.
+-type exchange()     :: binary().
+-type topic()        :: binary().
+-type exchange_opt() :: {durable, boolean()}.
+-type sample()       :: #{}.
 
 -record(state, {id :: term(),
                 host_opts :: host_opts(),
@@ -43,7 +44,11 @@ start_link(HostOpts, Opts) ->
 
 -spec publish(exchange(), topic(), [sample()]) -> ok.
 publish(Exchange, Topic, Payload) ->
-    gen_server:call(?SERVER, {publish, Exchange, Topic, Payload}).
+    publish(Exchange, Topic, Payload, [{durable, true}]).
+
+-spec publish(exchange(), topic(), [sample()], [exchange_opt()]) -> ok.
+publish(Exchange, Topic, Payload, ExchangeOpts) ->
+    gen_server:call(?SERVER, {publish, Exchange, Topic, Payload, ExchangeOpts}).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -64,8 +69,8 @@ init({HostOpts, #{id := ID} = Opts}) ->
                 channel = Ch}}.
 
 -spec handle_call(any(), any(), state()) -> {reply, ok, state()}.
-handle_call({publish, Exchange, Topic, Payload}, _From, State) ->
-    Reply = publish(Exchange, Topic, Payload, State),
+handle_call({publish, Exchange, Topic, Payload, ExchangeOpts}, _From, State) ->
+    Reply = do_publish(Exchange, Topic, Payload, ExchangeOpts, State),
     {reply, Reply, State};
 
 handle_call(_Request, _From, State) ->
@@ -99,19 +104,20 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
--spec publish(exchange(), topic(), [sample()], #state{}) -> ok.
-publish(Exchange, Topic, Messages,
-        State = #state{opts = #{chunk_size := S}}) when length(Messages) > S ->
+-spec do_publish(exchange(), topic(), [sample()], [exchange_opt()], #state{}) -> ok.
+do_publish(Exchange, Topic, Messages, ExchangeOpts,
+        State = #state{opts = #{chunk_size := S}})
+  when length(Messages) > S ->
     {H, T} = lists:split(S, Messages),
-    publish_chunk(Exchange, Topic, H, State),
-    publish(Exchange, Topic, T, State);
-publish(_Exchange, _Topic, [], _State) ->
+    publish_chunk(Exchange, Topic, H, ExchangeOpts, State),
+    do_publish(Exchange, Topic, T, ExchangeOpts, State);
+do_publish(_Exchange, _Topic, [], _ExchangeOpts, _State) ->
     ok;
-publish(Exchange, Topic, Messages, State) ->
-    publish_chunk(Exchange, Topic, Messages, State).
+do_publish(Exchange, Topic, Messages, ExchangeOpts, State) ->
+    publish_chunk(Exchange, Topic, Messages, ExchangeOpts, State).
 
--spec publish_chunk(exchange(), topic(), [sample()], #state{}) -> ok.
-publish_chunk(Exchange, Topic, Messages, #state{channel = Ch}) ->
+-spec publish_chunk(exchange(), topic(), [sample()], [exchange_opt()], #state{}) -> ok.
+publish_chunk(Exchange, Topic, Messages, ExchangeOpts, #state{channel = Ch}) ->
     %% TODO: remove assumption on JSON serialization
     Json = jsone:encode(Messages),
     lager:info("Publishing ~p samples to ~p exchange",
@@ -120,7 +126,7 @@ publish_chunk(Exchange, Topic, Messages, #state{channel = Ch}) ->
                                routing_key = Topic},
     M = #'amqp_msg'{props = #'P_basic'{content_type = <<"application/json">>},
                     payload = Json},
-    declare_exchange(Ch, Exchange),
+    declare_exchange(Ch, Exchange, ExchangeOpts),
     folsom_metrics:notify({?METRIC_OUT, {inc, 1}}),
     amqp_channel:cast(Ch, Command, M).
 
@@ -148,10 +154,11 @@ mk_params([{password, Pass} | Rest], Params) ->
     mk_params(Rest, Params#amqp_params_network{password = Pass}).
 
 %% TODO: Make exchange properties configurable
--spec declare_exchange(channel(), exchange()) -> ok.
-declare_exchange(Channel, Exchange) ->
+-spec declare_exchange(channel(), exchange(), [exchange_opt()]) -> ok.
+declare_exchange(Channel, Exchange, ExchangeOpts) ->
+    Durable = proplists:get_value(durable, ExchangeOpts, true),
     ExCommand = #'exchange.declare'{exchange = Exchange,
                                     type = <<"topic">>,
-                                    durable = true},
+                                    durable = Durable},
     #'exchange.declare_ok'{} = amqp_channel:call(Channel, ExCommand),
     ok.


### PR DESCRIPTION
In `docker-worker` we need to publish to exchanges on different virtual hosts with different settings for `durable`. This is the only change we need to support that.

I've made the change backwards compatible.

We don't need this merged because we have made the changes in a local copy.